### PR TITLE
Update demo.p8 to compile with latest prog8 compiler

### DIFF
--- a/p8demo/demo.p8
+++ b/p8demo/demo.p8
@@ -29,10 +29,10 @@ main $0830 {
 			beq _sync
 			rts
 _loop:
-			inc p8_loopchanged
+			inc p8v_loopchanged
 			rts
 _sync:
-			inc p8_beat
+			inc p8v_beat
 			rts
 		}}
 	}
@@ -63,7 +63,8 @@ _sync:
 		ubyte intensity = 0
 
 		repeat {
-			uword newjoy = cx16.joystick_get2(0)
+			uword newjoy
+			newjoy, void = cx16.joystick_get(0)
 			if (newjoy != oldjoy and (newjoy & $10) == 0) {
 				if (paused) {
 					zsmkit.zsm_play(0)


### PR DESCRIPTION
Fix prefixes for prog8 vars in asmsub.  p8_ -> p8v_
Fix joystick get to remove "2", and handle the two return params from it.